### PR TITLE
Reduce executen time for sql script

### DIFF
--- a/src/DummyDataGenerator.Backend/Connection.cs
+++ b/src/DummyDataGenerator.Backend/Connection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using DummyDataGenerator.Backend.Interfaces;
@@ -28,8 +27,6 @@ namespace DummyDataGenerator.Backend
       sb.Append(" VALUES ");
       sb.Append($"('{Customer.Id}',");
       sb.Append($"'{Vehicle.Id}')");
-      sb.Append(Environment.NewLine);
-      sb.Append("GO");
 
       return sb.ToString().Replace("''", "NULL");
     }

--- a/src/DummyDataGenerator.Backend/Customer.cs
+++ b/src/DummyDataGenerator.Backend/Customer.cs
@@ -81,8 +81,6 @@ namespace DummyDataGenerator.Backend
       sb.Append($"'{Phone}',");
       sb.Append($"'{Email}',");
       sb.Append($"{TimeForPaymentInDays})");
-      sb.Append(Environment.NewLine);
-      sb.Append("GO");
 
       return sb.ToString().Replace("''", "NULL");
     }

--- a/src/DummyDataGenerator.Backend/Vehicle.cs
+++ b/src/DummyDataGenerator.Backend/Vehicle.cs
@@ -68,8 +68,6 @@ namespace DummyDataGenerator.Backend
       sb.Append($"'{Tsn}',");
       sb.Append($"'{KTypeNumber}',");
       sb.Append($"{Mileage})");
-      sb.Append(Environment.NewLine);
-      sb.Append("GO");
 
       return sb.ToString().Replace("''", "NULL");
     }

--- a/test/DummyDataGenerator.Backend.Test/ConnectionTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/ConnectionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using FluentAssertions;
 using Xunit;

--- a/test/DummyDataGenerator.Backend.Test/ConnectionTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/ConnectionTests.cs
@@ -32,7 +32,8 @@ namespace DummyDataGenerator.Backend.Test
         var connection = new Connection(customer, vehicle);
         var script = connection.AsInsertScript();
 
-        script.Should().EndWith("GO");
+        script.Should().EndWith(")");
+        script.Should().NotEndWith(",)");
       }
     }
 

--- a/test/DummyDataGenerator.Backend.Test/CustomerTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/CustomerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions;
 using Xunit;
 

--- a/test/DummyDataGenerator.Backend.Test/CustomerTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/CustomerTests.cs
@@ -27,8 +27,8 @@ namespace DummyDataGenerator.Backend.Test
         var customer = new Customer(ddg);
         var script = customer.AsInsertScript();
 
-        script.Should().EndWith($"){Environment.NewLine}GO");
-        script.Should().NotEndWith($",){Environment.NewLine}GO");
+        script.Should().EndWith(")");
+        script.Should().NotEndWith(",)");
       }
     }
 

--- a/test/DummyDataGenerator.Backend.Test/VehicleTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/VehicleTests.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions;
 using Xunit;
 

--- a/test/DummyDataGenerator.Backend.Test/VehicleTests.cs
+++ b/test/DummyDataGenerator.Backend.Test/VehicleTests.cs
@@ -27,7 +27,8 @@ namespace DummyDataGenerator.Backend.Test
         var vehicle = new Vehicle(ddg);
         var script = vehicle.AsInsertScript();
 
-        script.Should().EndWith("GO");
+        script.Should().EndWith(")");
+        script.Should().NotEndWith(",)");
       }
     }
 


### PR DESCRIPTION
The execution time of the sql script can be dramatically reduced by removing GO statements.